### PR TITLE
feat: Add support for websocket client (MOVEMENT-1270, PERF-1285)

### DIFF
--- a/rosbridge_client/CMakeLists.txt
+++ b/rosbridge_client/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rosbridge_client)
+
+find_package(catkin REQUIRED)
+
+catkin_python_setup()
+
+catkin_package()
+
+install(PROGRAMS
+  scripts/rosbridge_websocket.py
+  scripts/rosbridge_websocket
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(FILES
+  launch/rosbridge_websocket.launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)
+

--- a/rosbridge_client/launch/rosbridge_websocket.launch
+++ b/rosbridge_client/launch/rosbridge_websocket.launch
@@ -1,0 +1,70 @@
+<launch>
+  <arg name="ssl" default="false" />
+  <arg name="certfile" default=""/>
+  <arg name="keyfile" default="" />
+
+  <arg name="retry_startup_delay" default="5" />
+
+  <arg name="fragment_timeout" default="600" />
+  <arg name="delay_between_messages" default="0" />
+  <arg name="max_message_size" default="None" />
+  <arg name="unregister_timeout" default="10" />
+  
+  <arg name="use_compression" default="false" />
+
+  <arg name="authenticate" default="false" />
+
+  <arg name="websocket_ping_interval" default="0" />
+  <arg name="websocket_ping_timeout" default="30" />
+  <arg name="websocket_null_origin" default="true" />
+
+  <arg name="topics_glob" default="[*]" />
+  <arg name="services_glob" default="[*]" />
+  <arg name="params_glob" default="[*]" />
+  <arg name="bson_only_mode" default="false" />
+
+  <!-- Valid options for binary_encoder are "default", "b64" and "bson". -->
+  <arg unless="$(arg bson_only_mode)" name="binary_encoder" default="default"/>
+
+  <group if="$(arg ssl)">
+    <node name="rosbridge_websocke_client" pkg="rosbridge_client" type="rosbridge_websocket" output="screen">
+      <param name="ros_bridge_socket_server_url" value="$(arg ros_bridge_socket_server_url)" />
+      <param name="certfile" value="$(arg certfile)" />
+      <param name="keyfile" value="$(arg keyfile)" />
+      <param name="authenticate" value="$(arg authenticate)" />
+      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
+      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
+      <param name="max_message_size" value="$(arg max_message_size)"/>
+      <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
+      <param name="use_compression" value="$(arg use_compression)"/>
+
+      <param name="websocket_ping_interval" value="$(arg websocket_ping_interval)" />
+      <param name="websocket_ping_timeout" value="$(arg websocket_ping_timeout)" />
+      <param name="websocket_null_origin" value="$(arg websocket_null_origin)" />
+
+      <param name="topics_glob" value="$(arg topics_glob)"/>
+      <param name="services_glob" value="$(arg services_glob)"/>
+      <param name="params_glob" value="$(arg params_glob)"/>
+    </node>
+  </group>
+  <group unless="$(arg ssl)">
+    <node name="rosbridge_websocke_client" pkg="rosbridge_client" type="rosbridge_websocket" output="screen">
+      <param name="ros_bridge_socket_server_url" value="$(arg ros_bridge_socket_server_url)" />
+      <param name="authenticate" value="$(arg authenticate)" />
+      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
+      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
+      <param name="max_message_size" value="$(arg max_message_size)"/>
+      <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
+      <param name="use_compression" value="$(arg use_compression)"/>
+
+      <param name="websocket_ping_interval" value="$(arg websocket_ping_interval)" />
+      <param name="websocket_ping_timeout" value="$(arg websocket_ping_timeout)" />
+
+      <param name="topics_glob" value="$(arg topics_glob)"/>
+      <param name="services_glob" value="$(arg services_glob)"/>
+      <param name="params_glob" value="$(arg params_glob)"/>
+
+      <param name="bson_only_mode" value="$(arg bson_only_mode)"/>
+    </node>
+  </group>
+</launch>

--- a/rosbridge_client/package.xml
+++ b/rosbridge_client/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>rosbridge_client</name>
+  <version>0.11.5</version>
+  <description>A WebSocket client interface for rosbridge to connect to a remote websocket server.</description>
+
+  <license>BSD</license>
+
+  <url type="website">http://ros.org/wiki/rosbridge_client</url>
+  <url type="bugtracker">https://github.com/RobotWebTools/rosbridge_suite/issues</url>
+  <url type="repository">https://github.com/RobotWebTools/rosbridge_suite</url>
+
+  <author email="dan@6river.com">Dan Winkler</author>
+  <maintainer email="dan@6river.com">Dan Winkler</maintainer>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-autobahn</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-autobahn</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-backports.ssl-match-hostname</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-tornado</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-tornado</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-twisted-core</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-twisted</exec_depend>
+  <exec_depend>rosbridge_library</exec_depend>
+  <exec_depend>rosbridge_msgs</exec_depend>
+  <exec_depend>rosapi</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosauth</exec_depend>
+  <test_depend>rostest</test_depend>
+</package>

--- a/rosbridge_client/scripts/rosbridge_websocket
+++ b/rosbridge_client/scripts/rosbridge_websocket
@@ -1,0 +1,1 @@
+rosbridge_websocket.py

--- a/rosbridge_client/scripts/rosbridge_websocket.py
+++ b/rosbridge_client/scripts/rosbridge_websocket.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2012, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+import rospy
+import sys
+
+from twisted.python import log
+from twisted.internet import reactor, ssl
+from twisted.internet.error import CannotListenError, ReactorNotRunning
+from distutils.version import LooseVersion
+import autobahn #to check version
+from autobahn.twisted.websocket import WebSocketServerFactory, connectWS
+from autobahn.websocket.compress import (PerMessageDeflateOffer,
+                                         PerMessageDeflateOfferAccept)
+log.startLogging(sys.stdout)
+
+from rosbridge_client import RosbridgeWebSocketClientProtocol, RosbridgeWebSocketClientFactory
+
+from rosbridge_library.capabilities.advertise import Advertise
+from rosbridge_library.capabilities.publish import Publish
+from rosbridge_library.capabilities.subscribe import Subscribe
+from rosbridge_library.capabilities.advertise_service import AdvertiseService
+from rosbridge_library.capabilities.unadvertise_service import UnadvertiseService
+from rosbridge_library.capabilities.call_service import CallService
+
+def shutdown_hook():
+    try:
+        reactor.stop()
+    except ReactorNotRunning:
+        rospy.logwarn("Can't stop the reactor, it wasn't running")
+
+
+if __name__ == "__main__":
+    rospy.init_node("rosbridge_websocket")
+    rospy.on_shutdown(shutdown_hook)    # register shutdown hook to stop the server
+
+    ##################################################
+    # Parameter handling                             #
+    ##################################################
+    use_compression = rospy.get_param('~use_compression', False)
+    socketServerURL = rospy.get_param('~ros_bridge_socket_server_url')
+
+   # get RosbridgeProtocol parameters
+    RosbridgeWebSocketClientProtocol.fragment_timeout = rospy.get_param('~fragment_timeout',
+                                                          RosbridgeWebSocketClientProtocol.fragment_timeout)
+    RosbridgeWebSocketClientProtocol.delay_between_messages = rospy.get_param('~delay_between_messages',
+                                                                RosbridgeWebSocketClientProtocol.delay_between_messages)
+    RosbridgeWebSocketClientProtocol.max_message_size = rospy.get_param('~max_message_size',
+                                                          RosbridgeWebSocketClientProtocol.max_message_size)
+    RosbridgeWebSocketClientProtocol.unregister_timeout = rospy.get_param('~unregister_timeout',
+                                                          RosbridgeWebSocketClientProtocol.unregister_timeout)
+    bson_only_mode = rospy.get_param('~bson_only_mode', False)
+
+    if RosbridgeWebSocketClientProtocol.max_message_size == "None":
+        RosbridgeWebSocketClientProtocol.max_message_size = None
+
+    ping_interval = float(rospy.get_param('~websocket_ping_interval', 0))
+    ping_timeout = float(rospy.get_param('~websocket_ping_timeout', 30))
+    null_origin = rospy.get_param('~websocket_null_origin', True) #default to original behaviour
+
+    # SSL options
+    certfile = rospy.get_param('~certfile', None)
+    keyfile = rospy.get_param('~keyfile', None)
+    # if authentication should be used
+    RosbridgeWebSocketClientProtocol.authenticate = rospy.get_param('~authenticate', False)
+
+    # Get the glob strings and parse them as arrays.
+    RosbridgeWebSocketClientProtocol.topics_glob = [
+        element.strip().strip("'")
+        for element in rospy.get_param('~topics_glob', '')[1:-1].split(',')
+        if len(element.strip().strip("'")) > 0]
+    RosbridgeWebSocketClientProtocol.services_glob = [
+        element.strip().strip("'")
+        for element in rospy.get_param('~services_glob', '')[1:-1].split(',')
+        if len(element.strip().strip("'")) > 0]
+    RosbridgeWebSocketClientProtocol.params_glob = [
+        element.strip().strip("'")
+        for element in rospy.get_param('~params_glob', '')[1:-1].split(',')
+        if len(element.strip().strip("'")) > 0]
+
+    if "--fragment_timeout" in sys.argv:
+        idx = sys.argv.index("--fragment_timeout") + 1
+        if idx < len(sys.argv):
+            RosbridgeWebSocketClientProtocol.fragment_timeout = int(sys.argv[idx])
+        else:
+            print("--fragment_timeout argument provided without a value.")
+            sys.exit(-1)
+
+    if "--delay_between_messages" in sys.argv:
+        idx = sys.argv.index("--delay_between_messages") + 1
+        if idx < len(sys.argv):
+            RosbridgeWebSocketClientProtocol.delay_between_messages = float(sys.argv[idx])
+        else:
+            print("--delay_between_messages argument provided without a value.")
+            sys.exit(-1)
+
+    if "--max_message_size" in sys.argv:
+        idx = sys.argv.index("--max_message_size") + 1
+        if idx < len(sys.argv):
+            value = sys.argv[idx]
+            if value == "None":
+                RosbridgeWebSocketClientProtocol.max_message_size = None
+            else:
+                RosbridgeWebSocketClientProtocol.max_message_size = int(value)
+        else:
+            print("--max_message_size argument provided without a value. (can be None or <Integer>)")
+            sys.exit(-1)
+
+    if "--unregister_timeout" in sys.argv:
+        idx = sys.argv.index("--unregister_timeout") + 1
+        if idx < len(sys.argv):
+            unregister_timeout = float(sys.argv[idx])
+        else:
+            print("--unregister_timeout argument provided without a value.")
+            sys.exit(-1)
+
+    if "--topics_glob" in sys.argv:
+        idx = sys.argv.index("--topics_glob") + 1
+        if idx < len(sys.argv):
+            value = sys.argv[idx]
+            if value == "None":
+                RosbridgeWebSocketClientProtocol.topics_glob = []
+            else:
+                RosbridgeWebSocketClientProtocol.topics_glob = [element.strip().strip("'") for element in value[1:-1].split(',')]
+        else:
+            print("--topics_glob argument provided without a value. (can be None or a list)")
+            sys.exit(-1)
+
+    if "--services_glob" in sys.argv:
+        idx = sys.argv.index("--services_glob") + 1
+        if idx < len(sys.argv):
+            value = sys.argv[idx]
+            if value == "None":
+                RosbridgeWebSocketClientProtocol.services_glob = []
+            else:
+                RosbridgeWebSocketClientProtocol.services_glob = [element.strip().strip("'") for element in value[1:-1].split(',')]
+        else:
+            print("--services_glob argument provided without a value. (can be None or a list)")
+            sys.exit(-1)
+
+    if "--params_glob" in sys.argv:
+        idx = sys.argv.index("--params_glob") + 1
+        if idx < len(sys.argv):
+            value = sys.argv[idx]
+            if value == "None":
+                RosbridgeWebSocketClientProtocol.params_glob = []
+            else:
+                RosbridgeWebSocketClientProtocol.params_glob = [element.strip().strip("'") for element in value[1:-1].split(',')]
+        else:
+            print("--params_glob argument provided without a value. (can be None or a list)")
+            sys.exit(-1)
+
+    if ("--bson_only_mode" in sys.argv) or bson_only_mode:
+        RosbridgeWebSocketClientProtocol.bson_only_mode = bson_only_mode
+
+    if "--websocket_ping_interval" in sys.argv:
+        idx = sys.argv.index("--websocket_ping_interval") + 1
+        if idx < len(sys.argv):
+            ping_interval = float(sys.argv[idx])
+        else:
+            print("--websocket_ping_interval argument provided without a value.")
+            sys.exit(-1)
+
+    if "--websocket_ping_timeout" in sys.argv:
+        idx = sys.argv.index("--websocket_ping_timeout") + 1
+        if idx < len(sys.argv):
+            ping_timeout = float(sys.argv[idx])
+        else:
+            print("--websocket_ping_timeout argument provided without a value.")
+            sys.exit(-1)
+
+    if "--websocket_external_port" in sys.argv:
+        idx = sys.argv.index("--websocket_external_port") + 1
+        if idx < len(sys.argv):
+            external_port = int(sys.argv[idx])
+        else:
+            print("--websocket_external_port argument provided without a value.")
+            sys.exit(-1)
+
+    # To be able to access the list of topics and services, you must be able to access the rosapi services.
+    if RosbridgeWebSocketClientProtocol.services_glob:
+        RosbridgeWebSocketClientProtocol.services_glob.append("/rosapi/*")
+
+    Subscribe.topics_glob = RosbridgeWebSocketClientProtocol.topics_glob
+    Advertise.topics_glob = RosbridgeWebSocketClientProtocol.topics_glob
+    Publish.topics_glob = RosbridgeWebSocketClientProtocol.topics_glob
+    AdvertiseService.services_glob = RosbridgeWebSocketClientProtocol.services_glob
+    UnadvertiseService.services_glob = RosbridgeWebSocketClientProtocol.services_glob
+    CallService.services_glob = RosbridgeWebSocketClientProtocol.services_glob
+
+    ##################################################
+    # Done with parameter handling                   #
+    ##################################################
+
+    def handle_compression_offers(offers):
+        if not use_compression:
+            return
+        for offer in offers:
+            if isinstance(offer, PerMessageDeflateOffer):
+                return PerMessageDeflateOfferAccept(offer)
+
+    factory = RosbridgeWebSocketClientFactory(socketServerURL)
+
+    # SSL client context: default
+    ##
+    if factory.isSecure:
+        print('Using client context factory')
+        context_factory = ssl.ClientContextFactory()
+    else:
+        context_factory = None
+
+    # https://github.com/crossbario/autobahn-python/commit/2ef13a6804054de74eb36455b58a64a3c701f889
+    if LooseVersion(autobahn.__version__) < LooseVersion("0.15.0"):
+        factory.setProtocolOptions(
+            perMessageCompressionAccept=handle_compression_offers,
+            autoPingInterval=ping_interval,
+            autoPingTimeout=ping_timeout,
+        )
+    else:
+        factory.setProtocolOptions(
+            perMessageCompressionAccept=handle_compression_offers,
+            autoPingInterval=ping_interval,
+            autoPingTimeout=ping_timeout,
+            allowNullOrigin=null_origin,
+        )
+
+    connectWS(factory, context_factory)
+    rospy.loginfo('Rosbridge WebSocket client started at {}'.format(socketServerURL))
+
+    rospy.on_shutdown(shutdown_hook)
+    reactor.run()

--- a/rosbridge_client/setup.py
+++ b/rosbridge_client/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=[
+        'rosbridge_client',
+    ],
+    package_dir={'': 'src'}
+)
+
+
+setup(**d)

--- a/rosbridge_client/src/rosbridge_client/__init__.py
+++ b/rosbridge_client/src/rosbridge_client/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+from .websocket_handler import RosbridgeWebSocketClientProtocol
+from .websocket_handler import RosbridgeWebSocketClientFactory

--- a/rosbridge_client/src/rosbridge_client/websocket_handler.py
+++ b/rosbridge_client/src/rosbridge_client/websocket_handler.py
@@ -1,0 +1,213 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2012, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+
+from rosauth.srv import Authentication
+
+import sys
+import threading
+import traceback
+from functools import wraps
+
+from twisted.python import log
+from twisted.internet import interfaces, reactor
+from twisted.internet.protocol import ReconnectingClientFactory
+from zope.interface import implementer
+
+from autobahn.twisted.websocket import WebSocketClientFactory, \
+    WebSocketClientProtocol
+
+from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
+from rosbridge_library.util import json, bson
+
+def _log_exception():
+    """Log the most recent exception to ROS."""
+    exc = traceback.format_exception(*sys.exc_info())
+    rospy.logerr(''.join(exc))
+
+
+def log_exceptions(f):
+    """Decorator for logging exceptions to ROS."""
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except:
+            _log_exception()
+            raise
+    return wrapper
+
+
+@implementer(interfaces.IPushProducer)
+class OutgoingValve:
+    """Allows the Autobahn transport to pause outgoing messages from rosbridge.
+    
+    The purpose of this valve is to connect backpressure from the WebSocket client
+    back to the rosbridge protocol, which depends on backpressure for queueing.
+    Without this flow control, rosbridge will happily keep writing messages to
+    the WebSocket until the system runs out of memory.
+
+    This valve is closed and opened automatically by the Twisted TCP server.
+    In practice, Twisted should only close the valve when its userspace write buffer
+    is full and it should only open the valve when that buffer is empty.
+
+    When the valve is closed, the rosbridge protocol instance's outgoing writes
+    must block until the valve is opened.
+    """
+    def __init__(self, proto):
+        self._proto = proto
+        self._valve = threading.Event()
+        self._finished = False
+
+    @log_exceptions
+    def relay(self, message):
+        self._valve.wait()
+        if self._finished:
+            return
+        reactor.callFromThread(self._proto.outgoing, message)
+
+    def pauseProducing(self):
+        if not self._finished:
+            self._valve.clear()
+
+    def resumeProducing(self):
+        self._valve.set()
+
+    def stopProducing(self):
+        self._finished = True
+        self._valve.set()
+
+class RosbridgeWebSocketClientProtocol(WebSocketClientProtocol):
+    client_id_seed = ""
+    authenticate = False
+
+    # The following are passed on to RosbridgeProtocol
+    # defragmentation.py:
+    fragment_timeout = 600                  # seconds
+    # protocol.py:
+    delay_between_messages = 0              # seconds
+    max_message_size = None                 # bytes
+    unregister_timeout = 10.0               # seconds
+    bson_only_mode = False
+    tcpNoDelay = True                       # turn off Nagle algorithm
+
+    def set_nodelay(self, nodelay):
+        self.tcpNoDelay = nodelay
+
+    def onConnect(self, response):
+        self.client_id_seed = response.peer
+        rospy.loginfo("Connected to websocket server: {0}".format(self.client_id_seed))
+
+    def onOpen(self):
+        rospy.loginfo("Connection opened to websocket server: {0}".format(self.client_id_seed))
+        cls = self.__class__
+        parameters = {
+            "fragment_timeout": cls.fragment_timeout,
+            "delay_between_messages": cls.delay_between_messages,
+            "max_message_size": cls.max_message_size,
+            "unregister_timeout": cls.unregister_timeout,
+            "bson_only_mode": cls.bson_only_mode
+        }
+        try:
+            self.protocol = RosbridgeProtocol(self.client_id_seed, parameters=parameters)
+            producer = OutgoingValve(self)
+            self.transport.registerProducer(producer, True)
+            producer.resumeProducing()
+            self.protocol.outgoing = producer.relay
+            self.authenticated = False
+        except Exception as exc:
+            rospy.logerr("Unable to accept incoming connection.  Reason: %s", str(exc))
+        if cls.authenticate:
+            rospy.loginfo("Awaiting proper authentication...")
+
+    def outgoing(self, message):
+        if type(message) == bson.BSON:
+            binary = True
+            message = bytes(message)
+        elif type(message) == bytearray:
+            binary = True
+            message = bytes(message)
+        else:
+            binary = False
+            message = message.encode('utf-8')
+
+        self.sendMessage(message, binary)
+
+    def onMessage(self, message, binary):
+        cls = self.__class__
+        if not binary:
+            message = message.decode('utf-8')
+        # check if we need to authenticate
+        if cls.authenticate and not self.authenticated:
+            try:
+                if cls.bson_only_mode:
+                    msg = bson.BSON(message).decode()
+                else:
+                    msg = json.loads(message)
+
+                if msg['op'] == 'auth':
+                    # check the authorization information
+                    auth_srv = rospy.ServiceProxy('authenticate', Authentication)
+                    resp = auth_srv(msg['mac'], msg['client'], msg['dest'],
+                                                  msg['rand'], rospy.Time(msg['t']), msg['level'],
+                                                  rospy.Time(msg['end']))
+                    self.authenticated = resp.authenticated
+                    if self.authenticated:
+                        rospy.loginfo("Client %d has authenticated.", self.protocol.client_id)
+                        return
+                # if we are here, no valid authentication was given
+                rospy.logwarn("Client %d did not authenticate. Closing connection.",
+                              self.protocol.client_id)
+                self.sendClose()
+            except:
+                # proper error will be handled in the protocol class
+                self.protocol.incoming(message)
+        else:
+            # no authentication required
+            self.protocol.incoming(message)
+
+    def onClose(self, wasClean, code, reason):
+        if hasattr(self, 'protocol'):
+            self.protocol.finish()
+
+        rospy.loginfo("Disconnected from websocket server: {0}".format(reason))
+
+class RosbridgeWebSocketClientFactory(WebSocketClientFactory, ReconnectingClientFactory):
+    maxDelay = 1
+    protocol = RosbridgeWebSocketClientProtocol
+
+    def clientConnectionFailed(self, connector, reason):
+        self.retry(connector)
+
+    def clientConnectionLost(self, connector, reason):
+        self.retry(connector)

--- a/rosbridge_suite/package.xml
+++ b/rosbridge_suite/package.xml
@@ -25,6 +25,7 @@
 
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>rosbridge_client</exec_depend>
   <exec_depend>rosapi</exec_depend>
 
   <export>


### PR DESCRIPTION
Add support for connecting to a websocket server as a connection via rosbridge.  See rosbridge_server for additional parameters.  Functionally equivalent to rosbridge_server except for the connect is from the rosbrdige_client socket client to a remote cloud socket server.

**Arguments**: ros_bridge_socket_server_url - Remote WebSocket server URL.

**Development Example**
roslaunch rosbridge_client rosbridge_websocket.launch ros_bridge_socket_server_url:="ws://host.docker.internal:3008"

**Cloud Example**
roslaunch rosbridge_client rosbridge_websocket.launch ros_bridge_socket_server_url:="ws://moso01.6river.org/cfs/chuckulator-api/"